### PR TITLE
Removed incorrect comments from examples

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -60,7 +60,6 @@ The library supports both variants, here's how a named argument should be passed
         {'a': 3, 'b': 4},
         {'a': 4, 'b': 5}
     ]
-    # args = range(1,6) would also work
 
     def multiply(a, b):
         return a*b
@@ -77,7 +76,6 @@ and for the positional arguments:
     # from pqdm.threads import pqdm
 
     args = [[1, 2], [2, 3], [3, 4], [4, 5]],
-    # args = range(1,6) would also work
 
     def multiply(a, b):
         return a*b


### PR DESCRIPTION
The examples for `argument_type='kwargs'` and `argument_type='args'` would not work if you followed the comment and tried to implement the args via `range(1, 6)`.